### PR TITLE
Force local-name in rosinstall to registered name

### DIFF
--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -126,6 +126,7 @@ def package_to_apkbuild(ros_distro, package_name,
         rosinstall = generate_rosinstall(
             ros_distro, [pkg.name], flat=True, tar=False,
             upstream_source_version=(True if upstream else False))
+        rosinstall[0]['git']['local-name'] = pkg.name
         if upstream:
             if commit_hash is not None:
                 rosinstall[0]['git']['version'] = commit_hash


### PR DESCRIPTION
fix `--upstream` for packages having different name between rosdistro and repository name