### PR TITLE
Fix commit date to include merge commit

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -119,6 +119,7 @@ for manifest in ${manifests}; do
   pkgname=$(basename ${pkgpath})
 
   commit_date=$(git -C ${pkgpath} log \
+                --full-history \
                 -n1 --format=%ad --date=format-local:'%Y%m%d%H%M%S' HEAD ${commit_date_path})
 
   # Copy files with filter


### PR DESCRIPTION
fix #85 

```
A (HEAD)
|\
B |
| C
|/
D
```
commit_date was pointed `B`. After this PR, it will be fixed to `A`.