### PR TITLE
Reduce build path length

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.rsa
 *.rsa.pub
+packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,20 +47,22 @@ RUN pip3 install /tmp/genapkbuild
 COPY build-repo.sh /
 COPY sign-repo-index.sh /
 
-USER builder
-
 ENV HOME="/home/builder"
 ENV PACKAGER_PRIVKEY="${HOME}/.abuild/builder@alpine-ros-experimental.rsa"
-ENV APORTSDIR="${HOME}/aports"
-ENV REPODIR="${HOME}/packages"
-ENV LOGDIR="${HOME}/logs"
+ENV APORTSDIR="/aports"
+ENV REPODIR="/packages"
+ENV LOGDIR="/logs"
 ENV SRCDIR="/src"
 ENV TZ=UTC
 ENV FORCE_LOCAL_VERSION=no
+
+RUN mkdir -p ${APORTSDIR} ${REPODIR} ${LOGDIR} ${SRCDIR} \
+  && chmod a+rwx ${APORTSDIR} ${REPODIR} ${LOGDIR} ${SRCDIR}
 
 ENV ROS_PYTHON_VERSION=2
 
 VOLUME ${SRCDIR}
 WORKDIR ${SRCDIR}
 
+USER builder
 ENTRYPOINT ["/build-repo.sh"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ In ROS package directory:
 ```shell
 docker run -it --rm \
   -v $(pwd):/src/$(basename $(pwd)):ro \
-  -v /tmp:/logdir -e LOGDIR=/logdir \
   alpineros/ros-abuild:3.7-kinetic
 ```
 
@@ -28,8 +27,17 @@ In ROS meta-package root directory:
 ```shell
 docker run -it --rm \
   -v $(pwd):/src:ro \
-  -v /tmp:/logdir -e LOGDIR=/logdir \
   alpineros/ros-abuild:3.7-kinetic
 ```
+
+To get generated apk package,
+1. Create a directory to store packages.
+    ```shell
+    mkdir -p /path/to/your/packages
+    ```
+2. Build with following arguments:
+    ```
+    -v /path/to/your/packages:/packages
+    ```
 
 If `*.rosinstall` file is present, packages specified in the file will be automatically cloned and built.

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -16,7 +16,7 @@ makedepends="@(' '.join(makedepends))"
 subpackages="$pkgname-dbg"
 
 source=""
-builddir="$startdir/apk-build"
+builddir="$startdir/abuild"
 srcdir="/tmp/dummy-src-dir"
 buildlog="$builddir/ros-abuild-build.log"
 checklog="$builddir/ros-abuild-check.log"

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -16,7 +16,7 @@ makedepends="@(' '.join(makedepends))"
 subpackages="$pkgname-dbg"
 
 source=""
-builddir="$startdir/apk-build-temporary"
+builddir="$startdir/apk-build"
 srcdir="/tmp/dummy-src-dir"
 buildlog="$builddir/ros-abuild-build.log"
 checklog="$builddir/ros-abuild-check.log"


### PR DESCRIPTION
rostest with launch arguments makes file path too long. It causes path too long error.
This reduces base path length.