### PR TITLE
Use fuzzy match for version_eq

### DIFF
--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -71,7 +71,8 @@ def ros_dependency_to_name_ver(dep):
     if dep.version_eq is not None:
         if version_spec != '':
             raise ValueError("dependency has more than one version spec")
-        version_spec = "=" + dep.version_eq
+        # =~: fuzzy matching (e.g. "=~1.6" matches with 1.6.* )
+        version_spec = "=~" + dep.version_eq
 
     if not dep.evaluated_condition:
         return None


### PR DESCRIPTION
fix #119
ref https://wiki.alpinelinux.org/wiki/Alpine_Linux_package_management#Holding_a_specific_package_back

e.g. if there are `1.2.3-r0`, `1.2.3-r1`, `1.2.4-r0` and `1.3.0-r0`

- `<depends version_eq="1.2.3-r0">` matches `1.2.3-r0`.
- `<depends version_eq="1.2.3">` matches `1.2.3-r0`, `1.2.3-r1`.
- `<depends version_eq="1.2">` matches `1.2.3-r0`, `1.2.3-r1`, `1.2.4-r0`.
- `<depends version_eq="1">` matches `1.2.3-r0`, `1.2.3-r1`, `1.2.4-r0`, `1.3.0-r0`.
