### PR TITLE
Overwrite JOBS and MAKEFLAGS environment variables

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -47,7 +47,7 @@ if [ ! -z "${JOBS}" ]; then
   sudo sed -i "s/export JOBS=.*/export JOBS=${JOBS}/" /etc/abuild.conf
 fi
 
-sudo sed -i 's/export MAKEFLAGS=-j$JOBS/export MAKEFLAGS="-j$JOBS -l$JOBS"/' /etc/abuild.conf
+sudo sed -i 's/export MAKEFLAGS=.*/export MAKEFLAGS="-j$JOBS -l$JOBS"/' /etc/abuild.conf
 
 if [ ! -z "${CFLAGS}" ]; then
   echo "Overwriting CFLAGS"

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -43,6 +43,12 @@ esac
 
 # Setup environment variables
 
+if [ ! -z "${JOBS}" ]; then
+  sudo sed -i "s/export JOBS=.*/export JOBS=${JOBS}/" /etc/abuild.conf
+fi
+
+sudo sed -i 's/export MAKEFLAGS=-j$JOBS/export MAKEFLAGS="-j$JOBS -l$JOBS"/' /etc/abuild.conf
+
 if [ ! -z "${CFLAGS}" ]; then
   echo "Overwriting CFLAGS"
   echo "original:"


### PR DESCRIPTION
This PR enables to overwrite `JOBS` and `MAKEFLAGS` environment variables to execute `make` on parallel jobs.
This will speed up the build time of `catkin_make_isolated`.