### PR TITLE
Add a step to validate existing .rosinstall files

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -133,8 +133,7 @@ fi
 
 ext_deps=$(find ${SRCDIR} -name "*.rosinstall" || true)
 for dep in ${ext_deps}; do
-  vcs validate --input ${dep}
-  if [ ! $? -eq 0 ]; then
+  if ! vcs validate --input ${dep}; then
     echo "Skipping ${dep}: no valid repository found."
     continue
   fi

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -133,6 +133,11 @@ fi
 
 ext_deps=$(find ${SRCDIR} -name "*.rosinstall" || true)
 for dep in ${ext_deps}; do
+  vcs validate --input ${dep}
+  if [ ! $? -eq 0 ]; then
+    echo "Skipping ${dep}: no valid repository found."
+    continue
+  fi
   vcs import --input ${dep} ${ext_pkg_option} ${VCS_OPTIONS} --workers 4 ${extsrc}
 done
 


### PR DESCRIPTION
When using a `.rosinstall` file with all repositories commented out or empty, the following error will occur on `master`:
```
Input data is not valid format: 'NoneType' object is not subscriptable
```
This PR uses the `validate` command from `vcstool` to skip "invalid" `.rosinstall` files before calling `vcs import`.
