### PR TITLE
Set destination for vcs import

### DIFF
--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -204,7 +204,7 @@ def package_to_apkbuild(ros_distro, package_name,
             f = open(pkglist, 'w')
             f.write(yaml.dump(rosinstall))
             f.close()
-            subprocess.check_output(['vcs', 'import', '--input', pkglist])
+            subprocess.check_output(['vcs', 'import', '--input', pkglist, tmpd])
             basepath = '/'.join([tmpd, rosinstall[0]['git']['local-name']])
 
             if 'read_manifest' in todo_upstream_clone and todo_upstream_clone['read_manifest']:


### PR DESCRIPTION
In `master`, the packages defined in `rosinstall` are cloned in the current directory instead of the temporary directory created for that purpose. It prevents the following steps to work as expected and end up with the following error when calling `pkg.evaluate_conditions(os.environ)`:
```
AttributeError: 'NoneType' object has no attribute 'evaluate_conditions'
```
This PR addresses that issue.