### PR TITLE
Allow to handle git repositories owned by outer container user

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -146,6 +146,13 @@ for dep in ${ext_deps}; do
 done
 
 
+# Allow to handle git repositories owned by outer container user
+
+for dir in $(find ${SRCDIR} -name ".git" -type d); do
+  git config --global --add safe.directory $(dirname ${dir})
+done
+
+
 # Generate APKBUILDs
 
 error=false


### PR DESCRIPTION
Fix:
```
fatal: unsafe repository ('/src/rospack' is owned by someone else)
To add an exception for this directory, call:
	git config --global --add safe.directory /src/rospack
```