### PR TITLE
Fix grep warning

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -72,10 +72,10 @@ build() {
   find src -type f | while read file; do
     h=$(head -n1 "$file")
     rewrite_shebang=false
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/env\s*python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/env\s*python$"; then
       rewrite_shebang=true
     fi
-    if echo $h | grep -q -s "^#\!\s*/usr/bin/python$"; then
+    if echo $h | grep -q -s "^#!\s*/usr/bin/python$"; then
       rewrite_shebang=true
     fi
     if [ $rewrite_shebang == "true" ]; then


### PR DESCRIPTION
Fix grep: warning: stray \ before !
No need to escape "!" in shell script.
(Only needed on shell command-line.)