### PR TITLE
Specify ROS_PACKAGE_PATH

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -27,6 +27,7 @@ if [ x${GENERATE_BUILD_LOGS} != "xyes" ]; then
   statuslog="/dev/null"
 fi
 
+export ROS_PACKAGE_PATH="$builddir/src/$_pkgname"
 export ROS_PYTHON_VERSION=@ros_python_version
 @[if rosinstall is not None]@
 rosinstall="@rosinstall"


### PR DESCRIPTION
Some packages like `rosgraph` requires to resolve self package path to load config file during test.