### PR TITLE
Create log directory

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -109,6 +109,11 @@ check() {
   echo "checking" >> $statuslog
   cd "$builddir"
 @[  if use_catkin]@
+
+  logdir="$builddir/log"
+  mkdir -p "$logdir"
+  export ROS_LOG_DIR="$logdir"
+
   source /usr/ros/@(ros_distro)/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -110,9 +110,11 @@ check() {
   cd "$builddir"
 @[  if use_catkin]@
 
-  logdir="$builddir/log"
-  mkdir -p "$logdir"
-  export ROS_LOG_DIR="$logdir"
+  if [ -z "$ROS_LOG_DIR" ]; then
+    logdir="$builddir/log"
+    mkdir -p "$logdir"
+    export ROS_LOG_DIR="$logdir"
+  fi
 
   source /usr/ros/@(ros_distro)/setup.sh
   source devel_isolated/setup.sh


### PR DESCRIPTION
Fix following warning:
WARNING: cannot create log directory [/home/builder/.ros/log].
Please set ROS_LOG_DIR to a writable location.