### PR TITLE
Fix version_eq representation

### DIFF
--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -71,8 +71,9 @@ def ros_dependency_to_name_ver(dep):
     if dep.version_eq is not None:
         if version_spec != '':
             raise ValueError("dependency has more than one version spec")
-        # =~: fuzzy matching (e.g. "=~1.6" matches with 1.6.* )
-        version_spec = "=~" + dep.version_eq
+        # ~: specify version ignoring revisions
+        # https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#$pkgname~$pkgver
+        version_spec = "~" + dep.version_eq
 
     if not dep.evaluated_condition:
         return None


### PR DESCRIPTION
Specifying `package=~1.2.3` results `Invalid version: ~1.2.3` on 3.17.
`package~1.2.3` should be correct.
https://wiki.alpinelinux.org/wiki/APKBUILD_Reference#$pkgname~$pkgver