### PR TITLE
Output dependency resolution errors to symmary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apk add --no-cache \
     python3 \
     py3-pip \
     py3-yaml \
+    sed \
   && pip3 install \
     requests \
     rosdep \

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -373,7 +373,7 @@ if [ ${dep_error_lines} -gt 0 ]; then
     echo "error log exceeded 50 lines (total ${lines} lines)" >> ${summary_file}
   fi
   echo '```' >> ${summary_file}
-  echo "${dep_errors}" | head -n100 >> ${summary_file}
+  echo "${dep_errors}" | head -n50 >> ${summary_file}
   echo '```' >> ${summary_file}
 fi
 

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -360,6 +360,19 @@ for manifest in ${manifests}; do
   fi
 done
 
+# Extract dependency error logs
+dep_errors=$(sed -n '/^ERROR: unable to select packages/{p; :loop; n; /^\s/{p; b loop}; /^>>>/{b loop}/}')
+if [ -n "${dep_errors}" ]; then
+  lines=$(echo -n "${dep_errors}" | wc -l)
+  echo "## Dependency logs" >> ${summary_file}
+  if [ ${lines} -gt 50 ]; then
+    echo "error log exceeded 50 lines (total ${lines} lines)"
+  fi
+  echo '```' >> ${summary_file}
+  echo "${dep_errors}" | head -n100 >> ${summary_file}
+  echo '```' >> ${summary_file}
+fi
+
 echo
 echo "---"
 cat ${summary_file}

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -280,7 +280,7 @@ fi
 
 # Build everything
 
-GENERATE_BUILD_LOGS=yes buildrepo -k -d ${REPODIR} -a ${APORTSDIR} ${repo} | tee ${full_log_file}
+GENERATE_BUILD_LOGS=yes buildrepo -k -d ${REPODIR} -a ${APORTSDIR} ${repo} 2>&1 | tee ${full_log_file}
 
 
 # Summarize build result
@@ -361,12 +361,16 @@ for manifest in ${manifests}; do
 done
 
 # Extract dependency error logs
-dep_errors=$(sed -n '/^ERROR: unable to select packages/{p; :loop; n; /^\s/{p; b loop}; /^>>>/{b loop}/}' ${full_log_file})
-if [ -n "${dep_errors}" ]; then
-  lines=$(echo -n "${dep_errors}" | wc -l)
+dep_errors=$(sed -n '/^ERROR: unable to select packages/{p; :loop; n; /^\s/{p; b loop}; /^>>>/{b loop}}' ${full_log_file})
+dep_error_lines=$(echo -n "${dep_errors}" | wc -l)
+echo "${dep_error_lines}"
+if [ ${dep_error_lines} -gt 0 ]; then
+  echo >> ${summary_file}
+  echo '---' >> ${summary_file}
+  echo >> ${summary_file}
   echo "## Dependency logs" >> ${summary_file}
-  if [ ${lines} -gt 50 ]; then
-    echo "error log exceeded 50 lines (total ${lines} lines)"
+  if [ ${dep_error_lines} -gt 50 ]; then
+    echo "error log exceeded 50 lines (total ${lines} lines)" >> ${summary_file}
   fi
   echo '```' >> ${summary_file}
   echo "${dep_errors}" | head -n100 >> ${summary_file}

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -361,7 +361,7 @@ for manifest in ${manifests}; do
 done
 
 # Extract dependency error logs
-dep_errors=$(sed -n '/^ERROR: unable to select packages/{p; :loop; n; /^\s/{p; b loop}; /^>>>/{b loop}/}')
+dep_errors=$(sed -n '/^ERROR: unable to select packages/{p; :loop; n; /^\s/{p; b loop}; /^>>>/{b loop}/}' ${full_log_file})
 if [ -n "${dep_errors}" ]; then
   lines=$(echo -n "${dep_errors}" | wc -l)
   echo "## Dependency logs" >> ${summary_file}


### PR DESCRIPTION
Output will be like

```
...
## hoge
**ros-noetic-hoge-1.30.2_git20221201003408-r0.apk**
Already been built.

## Dependency logs
\```
ERROR: unable to select packages:
  .makedepends-ros-noetic-foo-20230119.034057:
    masked in: cache
    satisfies: world[.makedepends-ros-noetic-foo=20230119.034057]
  ros-noetic-bar (no such package):
    required by: .makedepends-ros-noetic-foo-20230119.034057[ros-noetic-bar>=1.23.4]
...
```
