### PR TITLE
Print the package name on dependencies resolution error

### DIFF
--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -89,7 +89,7 @@ def load_lookup():
     return lookup
 
 
-def resolve(ros_distro, deps):
+def resolve(ros_distro, package_name, deps):
     lookup = load_lookup()
     installer_context = rosdep2.create_default_installer_context()
     os_name, os_version = installer_context.get_os_name_and_version()
@@ -123,7 +123,8 @@ def resolve(ros_distro, deps):
         for r in resolved:
             keys.append(r + dep.version)
     if len(not_provided) > 0:
-        print('Some package is not provided by native installer: ' + ' '.join(not_provided), file=sys.stderr)
+        print('Some packages are not provided by the native installer for ' + package_name +
+              ': ' + ' '.join(not_provided), file=sys.stderr)
         return None
     return keys
 
@@ -232,14 +233,14 @@ def package_to_apkbuild(ros_distro, package_name,
     depends = []
     for dep in pkg.exec_depends:
         depends.append(ros_dependency_to_name_ver(dep))
-    depends_keys = resolve(ros_distro, depends)
+    depends_keys = resolve(ros_distro, package_name, depends)
 
     depends_export = []
     for dep in pkg.buildtool_export_depends:
         depends_export.append(ros_dependency_to_name_ver(dep))
     for dep in pkg.build_export_depends:
         depends_export.append(ros_dependency_to_name_ver(dep))
-    depends_export_keys = resolve(ros_distro, depends_export)
+    depends_export_keys = resolve(ros_distro, package_name, depends_export)
 
     makedepends = []
     catkin = False
@@ -258,7 +259,7 @@ def package_to_apkbuild(ros_distro, package_name,
         makedepends.append(ros_dependency_to_name_ver(dep))
     for dep in pkg.test_depends:
         makedepends.append(ros_dependency_to_name_ver(dep))
-    makedepends_keys = resolve(ros_distro, makedepends)
+    makedepends_keys = resolve(ros_distro, package_name, makedepends)
 
     if depends_keys is None or depends_export_keys is None or makedepends_keys is None:
         sys.exit(1)


### PR DESCRIPTION
Adding the package name in the error message can help debugging errors as in https://github.com/seqsense/aports-ros-updater/actions/runs/4099187171/jobs/7068859440.