### PR TITLE
Specify LD_LIBRARY_PATH in check() when building ament packages

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -156,6 +156,7 @@ check() {
   export PYTHONPATH="$builddir"/tmp/pkg/usr/ros/@(ros_distro)/lib/python${PYTHON_VERSION}/site-packages:${PYTHONPATH}
   export AMENT_PREFIX_PATH="$builddir"/tmp/pkg/usr/ros/@(ros_distro):${AMENT_PREFIX_PATH}
   export PATH="$builddir"/tmp/pkg/usr/ros/@(ros_distro)/bin:${PATH}
+  export LD_LIBRARY_PATH="$builddir"/tmp/pkg/usr/ros/@(ros_distro)/lib:${LD_LIBRARY_PATH}
   mkdir -p "$builddir"/tmp/pkg
 @[  end if]@
 @[  if use_cmake or use_ament_cmake]@


### PR DESCRIPTION
Some packages require this setting (e.g., [robot_state_publisher](https://github.com/ros/robot_state_publisher) for ROS 2) to load the built `.so` successfully when testing.

According to the official ROS 2 docker image, we should specify these 4 paths to use installed packages.
```
# env | grep /opt/ros
AMENT_PREFIX_PATH=/opt/ros/humble
PYTHONPATH=/opt/ros/humble/lib/python3.10/site-packages:/opt/ros/humble/local/lib/python3.10/dist-packages
LD_LIBRARY_PATH=/opt/ros/humble/lib/x86_64-linux-gnu:/opt/ros/humble/lib
PATH=/opt/ros/humble/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```