### PR TITLE
Fix genapkbuild.py to set build_type to cmake for ROS1 packages whose buildtool_depend is not catkin

### DIFF
--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -268,7 +268,7 @@ def package_to_apkbuild(ros_distro, package_name,
     build_type = pkg.get_build_type()
     if not is_ros2 and not pkg.has_buildtool_depend_on_catkin():
         build_type = 'cmake'
-    if build_type == 'catkin':
+    elif build_type == 'catkin':
         catkin = True
     elif build_type == 'cmake':
         cmake = True

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -266,6 +266,8 @@ def package_to_apkbuild(ros_distro, package_name,
     ament_python = False
 
     build_type = pkg.get_build_type()
+    if not is_ros2 and not pkg.has_buildtool_depend_on_catkin():
+        build_type = 'cmake'
     if build_type == 'catkin':
         catkin = True
     elif build_type == 'cmake':

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -267,7 +267,7 @@ def package_to_apkbuild(ros_distro, package_name,
 
     build_type = pkg.get_build_type()
     if not is_ros2 and not pkg.has_buildtool_depend_on_catkin():
-        build_type = 'cmake'
+        cmake = True
     elif build_type == 'catkin':
         catkin = True
     elif build_type == 'cmake':


### PR DESCRIPTION
`build_type` is not specified in `package.xml` of `catkin` package. In this case, [`get_build_type()`](https://github.com/ros-infrastructure/catkin_pkg/blob/03bc290d2ccf66dce2fa84632ac611b71bfa8f74/src/catkin_pkg/package.py#L150) returns "catkin". This has changed [`APKBUILD`](https://github.com/seqsense/aports-ros-experimental/pull/799/files#diff-a7f8afc3c1c1b66cf7d54f59e5dc0e8fa77b46b6786ca4729e3466ab7b4e309dL54-R71) of `catkin` package to build it by `catkin`.

By this PR, `build_type` is overwritten if the package is not ROS 2 and not buildtool_depend==catkin.
(originally reported by @at-wat)