### PR TITLE
Split dev packages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
         env:
           - ALPINE_VERSION=3.17 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
           - ALPINE_VERSION=3.17 ROS_DISTRO=humble ROS_DISTRIBUTION_TYPE=ros2
-          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 TEST_SPLIT_DEV=true
+          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 SPLIT_DEV=true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -46,10 +46,11 @@ jobs:
             rm -rf /tmp/ament_index
           fi
           echo "image=ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}" | tee -a ${GITHUB_OUTPUT}
-          echo "split-dev=${TEST_SPLIT_DEV}" | tee -a ${GITHUB_OUTPUT}
+          echo "split-dev=${SPLIT_DEV}" | tee -a ${GITHUB_OUTPUT}
           echo "pkg-name=${pkg_name}" | tee -a ${GITHUB_OUTPUT}
           echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name//_/-}" | tee -a ${GITHUB_OUTPUT}
       - name: Test
+        if: steps.test-data.outputs.split-dev != 'true'
         run: |
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,11 +16,15 @@ jobs:
         env:
           - ALPINE_VERSION=3.17 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
           - ALPINE_VERSION=3.17 ROS_DISTRO=humble ROS_DISTRIBUTION_TYPE=ros2
-          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
-          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 SPLIT_DEV=yes
+          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 TEST_SPLIT_DEV=true
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Extract test mode
+        id: test-mode
+        run: |
+          eval ${{ matrix.env }}
+          echo "split-dev=${TEST_SPLIT_DEV}" | tee ${GITHUB_OUTPUT}
 
       - name: Build image
         run: |
@@ -31,10 +35,10 @@ jobs:
             --build-arg ALPINE_VERSION=${ALPINE_VERSION} \
             --build-arg ROS_DISTRO=${ROS_DISTRO} \
             .
-      - name: Test
+
+      - name: Clone sample ROS package
         run: |
           eval ${{ matrix.env }}
-          image="ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}"
 
           if [[ ${ROS_DISTRIBUTION_TYPE} == "ros1" ]]; then
             pkg_name="rospack"
@@ -46,6 +50,10 @@ jobs:
             mv /tmp/ament_index/${pkg_name} /tmp/${pkg_name}
             rm -rf /tmp/ament_index
           fi
+      - name: Test
+        run: |
+          eval ${{ matrix.env }}
+          image="ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}"
 
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks
@@ -63,10 +71,31 @@ jobs:
           ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-doc-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking main package"
           ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-[[:alnum:]\._git]\+-r0.apk"
-          if [ "${SPLIT_DEV:-}" = 'yes' ]; then
-            echo "Checking dev package"
-            ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dev-[[:alnum:]\._git]\+-r0.apk"
-          fi
+
+          rm -rf /tmp/apks
+      - name: Test with split-dev
+        if: steps.test-mode.outputs.split-dev
+        run: |
+          mkdir -p /tmp/apks
+          chmod a+w /tmp/apks
+          docker run --rm \
+            -v /tmp/${pkg_name}:/src/${pkg_name}:ro \
+            -v /tmp/apks:/packages \
+            -e SPLIT_DEV=yes \
+            ${image}
+
+          pkg_name=${pkg_name//_/-}
+          ls -l /tmp/apks/*/*
+          echo "Checking -dbg subpackage"
+          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dbg-[[:alnum:]\._git]\+-r0.apk"
+          echo "Checking -doc subpackage"
+          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-doc-[[:alnum:]\._git]\+-r0.apk"
+          echo "Checking main package"
+          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-[[:alnum:]\._git]\+-r0.apk"
+          echo "Checking dev package"
+          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dev-[[:alnum:]\._git]\+-r0.apk"
+
+          rm -rf /tmp/apks
 
       - name: Login to GitHub Container Registry
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,7 @@ jobs:
           - ALPINE_VERSION=3.17 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
           - ALPINE_VERSION=3.17 ROS_DISTRO=humble ROS_DISTRIBUTION_TYPE=ros2
           - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
+          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 SPLIT_DEV=true OPTS=--split-dev
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -50,7 +51,8 @@ jobs:
           docker run --rm \
             -v /tmp/${pkg_name}:/src/${pkg_name}:ro \
             -v /tmp/apks:/packages \
-            ${image}
+            ${image} \
+            ${OPTS}
 
           pkg_name=${pkg_name//_/-}
           ls -l /tmp/apks/*/*
@@ -60,6 +62,10 @@ jobs:
           ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-doc-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking main package"
           ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-[[:alnum:]\._git]\+-r0.apk"
+          if [ "${SPLIT_DEV}" = 'true' ]; then
+            echo "Checking dev package"
+            ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dev-[[:alnum:]\._git]\+-r0.apk"
+          fi
 
       - name: Login to GitHub Container Registry
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,12 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Extract test mode
-        id: test-mode
-        run: |
-          eval ${{ matrix.env }}
-          echo "split-dev=${TEST_SPLIT_DEV}" | tee ${GITHUB_OUTPUT}
-
       - name: Build image
         run: |
           eval ${{ matrix.env }}
@@ -36,7 +30,8 @@ jobs:
             --build-arg ROS_DISTRO=${ROS_DISTRO} \
             .
 
-      - name: Clone sample ROS package
+      - name: Prepare test data
+        id: test-data
         run: |
           eval ${{ matrix.env }}
 
@@ -50,6 +45,9 @@ jobs:
             mv /tmp/ament_index/${pkg_name} /tmp/${pkg_name}
             rm -rf /tmp/ament_index
           fi
+          echo "split-dev=${TEST_SPLIT_DEV}" | tee ${GITHUB_OUTPUT}
+          echo "pkg-name=${pkg_name}" | tee ${GITHUB_OUTPUT}
+          echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name}" | tee ${GITHUB_OUTPUT}
       - name: Test
         run: |
           eval ${{ matrix.env }}
@@ -58,19 +56,17 @@ jobs:
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks
           docker run --rm \
-            -v /tmp/${pkg_name}:/src/${pkg_name}:ro \
+            -v /tmp/${{ steps.test-data.outputs.pkg-name }}:/src/${{ steps.test-data.outputs.pkg-name }}:ro \
             -v /tmp/apks:/packages \
-            -e SPLIT_DEV=${SPLIT_DEV} \
             ${image}
 
-          pkg_name=${pkg_name//_/-}
           ls -l /tmp/apks/*/*
           echo "Checking -dbg subpackage"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dbg-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dbg-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking -doc subpackage"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-doc-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-doc-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking main package"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-[[:alnum:]\._git]\+-r0.apk"
 
           rm -rf /tmp/apks
       - name: Test with split-dev
@@ -79,21 +75,20 @@ jobs:
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks
           docker run --rm \
-            -v /tmp/${pkg_name}:/src/${pkg_name}:ro \
+            -v /tmp/${{ steps.test-data.outputs.pkg-name }}:/src/${{ steps.test-data.outputs.pkg-name }}:ro \
             -v /tmp/apks:/packages \
             -e SPLIT_DEV=yes \
             ${image}
 
-          pkg_name=${pkg_name//_/-}
           ls -l /tmp/apks/*/*
           echo "Checking -dbg subpackage"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dbg-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dbg-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking -doc subpackage"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-doc-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-doc-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking main package"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking dev package"
-          ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dev-[[:alnum:]\._git]\+-r0.apk"
+          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dev-[[:alnum:]\._git]\+-r0.apk"
 
           rm -rf /tmp/apks
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -49,8 +49,7 @@ jobs:
           echo "split-dev=${SPLIT_DEV}" | tee -a ${GITHUB_OUTPUT}
           echo "pkg-name=${pkg_name}" | tee -a ${GITHUB_OUTPUT}
           echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name//_/-}" | tee -a ${GITHUB_OUTPUT}
-      - name: Test
-        if: steps.test-data.outputs.split-dev != 'true'
+      - name: Build sample package
         run: |
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks
@@ -58,7 +57,8 @@ jobs:
             -v /tmp/${{ steps.test-data.outputs.pkg-name }}:/src/${{ steps.test-data.outputs.pkg-name }}:ro \
             -v /tmp/apks:/packages \
             ${{ steps.test-data.outputs.image }}
-
+      - name: Test
+        run:
           ls -l /tmp/apks/*/*
           echo "Checking -dbg subpackage"
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dbg-[[:alnum:]\._git]\+-r0.apk"
@@ -66,30 +66,11 @@ jobs:
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-doc-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking main package"
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-[[:alnum:]\._git]\+-r0.apk"
-
-          sudo rm -rf /tmp/apks
-      - name: Test with split-dev
+      - name: Test split-dev
         if: steps.test-data.outputs.split-dev
         run: |
-          mkdir -p /tmp/apks
-          chmod a+w /tmp/apks
-          docker run --rm \
-            -v /tmp/${{ steps.test-data.outputs.pkg-name }}:/src/${{ steps.test-data.outputs.pkg-name }}:ro \
-            -v /tmp/apks:/packages \
-            -e SPLIT_DEV=yes \
-            ${{ steps.test-data.outputs.image }}
-
-          ls -l /tmp/apks/*/*
-          echo "Checking -dbg subpackage"
-          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dbg-[[:alnum:]\._git]\+-r0.apk"
-          echo "Checking -doc subpackage"
-          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-doc-[[:alnum:]\._git]\+-r0.apk"
-          echo "Checking main package"
-          ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking dev package"
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dev-[[:alnum:]\._git]\+-r0.apk"
-
-          sudo rm -rf /tmp/apks
 
       - name: Login to GitHub Container Registry
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -47,7 +47,7 @@ jobs:
           fi
           echo "split-dev=${TEST_SPLIT_DEV}" | tee ${GITHUB_OUTPUT}
           echo "pkg-name=${pkg_name}" | tee ${GITHUB_OUTPUT}
-          echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name}" | tee ${GITHUB_OUTPUT}
+          echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name//_/-}" | tee ${GITHUB_OUTPUT}
       - name: Test
         run: |
           eval ${{ matrix.env }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,7 +68,7 @@ jobs:
           echo "Checking main package"
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-[[:alnum:]\._git]\+-r0.apk"
 
-          rm -rf /tmp/apks
+          sudo rm -rf /tmp/apks
       - name: Test with split-dev
         if: steps.test-mode.outputs.split-dev
         run: |
@@ -90,7 +90,7 @@ jobs:
           echo "Checking dev package"
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dev-[[:alnum:]\._git]\+-r0.apk"
 
-          rm -rf /tmp/apks
+          sudo rm -rf /tmp/apks
 
       - name: Login to GitHub Container Registry
         if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
           - ALPINE_VERSION=3.17 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
           - ALPINE_VERSION=3.17 ROS_DISTRO=humble ROS_DISTRIBUTION_TYPE=ros2
           - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1
-          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 SPLIT_DEV=true OPTS=--split-dev
+          - ALPINE_VERSION=3.20 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1 SPLIT_DEV=yes
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,8 +51,8 @@ jobs:
           docker run --rm \
             -v /tmp/${pkg_name}:/src/${pkg_name}:ro \
             -v /tmp/apks:/packages \
-            ${image} \
-            ${OPTS}
+            -e SPLIT_DEV=${SPLIT_DEV} \
+            ${image}
 
           pkg_name=${pkg_name//_/-}
           ls -l /tmp/apks/*/*
@@ -62,7 +62,7 @@ jobs:
           ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-doc-[[:alnum:]\._git]\+-r0.apk"
           echo "Checking main package"
           ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-[[:alnum:]\._git]\+-r0.apk"
-          if [ "${SPLIT_DEV}" = 'true' ]; then
+          if [ "${SPLIT_DEV:-}" = 'yes' ]; then
             echo "Checking dev package"
             ls -l /tmp/apks/*/* | grep -e "ros-${ROS_DISTRO}-${pkg_name}-dev-[[:alnum:]\._git]\+-r0.apk"
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         env:
           - ALPINE_VERSION=3.17 ROS_DISTRO=noetic ROS_DISTRIBUTION_TYPE=ros1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,7 +58,7 @@ jobs:
             -v /tmp/apks:/packages \
             ${{ steps.test-data.outputs.image }}
       - name: Test
-        run:
+        run: |
           ls -l /tmp/apks/*/*
           echo "Checking -dbg subpackage"
           ls -l /tmp/apks/*/* | grep -e "${{ steps.test-data.outputs.apk-pkg-name }}-dbg-[[:alnum:]\._git]\+-r0.apk"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -70,7 +70,7 @@ jobs:
 
           sudo rm -rf /tmp/apks
       - name: Test with split-dev
-        if: steps.test-mode.outputs.split-dev
+        if: steps.test-data.outputs.split-dev
         run: |
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,20 +45,18 @@ jobs:
             mv /tmp/ament_index/${pkg_name} /tmp/${pkg_name}
             rm -rf /tmp/ament_index
           fi
+          echo "image=ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}" | tee ${GITHUB_OUTPUT}
           echo "split-dev=${TEST_SPLIT_DEV}" | tee ${GITHUB_OUTPUT}
           echo "pkg-name=${pkg_name}" | tee ${GITHUB_OUTPUT}
           echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name//_/-}" | tee ${GITHUB_OUTPUT}
       - name: Test
         run: |
-          eval ${{ matrix.env }}
-          image="ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}"
-
           mkdir -p /tmp/apks
           chmod a+w /tmp/apks
           docker run --rm \
             -v /tmp/${{ steps.test-data.outputs.pkg-name }}:/src/${{ steps.test-data.outputs.pkg-name }}:ro \
             -v /tmp/apks:/packages \
-            ${image}
+            ${{ steps.test-data.outputs.image }}
 
           ls -l /tmp/apks/*/*
           echo "Checking -dbg subpackage"
@@ -78,7 +76,7 @@ jobs:
             -v /tmp/${{ steps.test-data.outputs.pkg-name }}:/src/${{ steps.test-data.outputs.pkg-name }}:ro \
             -v /tmp/apks:/packages \
             -e SPLIT_DEV=yes \
-            ${image}
+            ${{ steps.test-data.outputs.image }}
 
           ls -l /tmp/apks/*/*
           echo "Checking -dbg subpackage"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -45,10 +45,10 @@ jobs:
             mv /tmp/ament_index/${pkg_name} /tmp/${pkg_name}
             rm -rf /tmp/ament_index
           fi
-          echo "image=ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}" | tee ${GITHUB_OUTPUT}
-          echo "split-dev=${TEST_SPLIT_DEV}" | tee ${GITHUB_OUTPUT}
-          echo "pkg-name=${pkg_name}" | tee ${GITHUB_OUTPUT}
-          echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name//_/-}" | tee ${GITHUB_OUTPUT}
+          echo "image=ros-abuild:${ALPINE_VERSION}-${ROS_DISTRO}" | tee -a ${GITHUB_OUTPUT}
+          echo "split-dev=${TEST_SPLIT_DEV}" | tee -a ${GITHUB_OUTPUT}
+          echo "pkg-name=${pkg_name}" | tee -a ${GITHUB_OUTPUT}
+          echo "apk-pkg-name=ros-${ROS_DISTRO}-${pkg_name//_/-}" | tee -a ${GITHUB_OUTPUT}
       - name: Test
         run: |
           mkdir -p /tmp/apks

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,8 @@ FROM alpine:${ALPINE_VERSION}
 ARG ALPINE_VERSION=3.17
 ARG ROS_DISTRO=noetic
 
-ENV ROS_DISTRO=${ROS_DISTRO}
+ENV ROS_DISTRO=${ROS_DISTRO} \
+  ALPINE_VERSION=${ALPINE_VERSION}
 
 RUN apk add --no-cache alpine-sdk lua-aports sudo \
   && adduser -G abuild -D builder \

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -79,17 +79,11 @@ case "${SKIP_ROSDEP_UPDATE}" in
 esac
 
 generate_opts=
-case "${SPLIT_DEV}" in
-  "")
-    ;;
-  yes)
+case "${ALPINE_VERSION}" in
+  3.20)
     generate_opts="${generate_opts} --split-dev"
     ;;
-  no)
-    ;;
   *)
-    echo "SPLIT_DEV must be one of: \"yes\", \"no\", \"\" (default: \"no\")"
-    exit 1
     ;;
 esac
 

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -78,6 +78,20 @@ case "${SKIP_ROSDEP_UPDATE}" in
     ;;
 esac
 
+generate_opts=
+case "${SPLIT_DEV}" in
+  "")
+    ;;
+  yes)
+    generate_opts="${generate_opts} --split-dev"
+    ;;
+  no)
+    ;;
+  *)
+    echo "SPLIT_DEV must be one of: \"yes\", \"no\", \"\" (default: \"no\")"
+    exit 1
+    ;;
+esac
 
 # Setup environment variables
 
@@ -240,7 +254,8 @@ for manifest in ${manifests}; do
 
   if ! (set -o pipefail && generate-rospkg-apkbuild \
     ${repo} ${APORTSDIR}/${repo}/${pkgname}/package.xml --src \
-      --ver-suffix=${ver_suffix} \
+        --ver-suffix=${ver_suffix} \
+        ${generate_opts} \
       | tee ${APORTSDIR}/${repo}/${pkgname}/APKBUILD); then
     echo "## Package dependency failure" >> ${summary_file}
     error=true

--- a/build-repo.sh
+++ b/build-repo.sh
@@ -87,6 +87,8 @@ case "${ALPINE_VERSION}" in
     ;;
 esac
 
+echo "generate_opts: ${generate_opts}"
+
 # Setup environment variables
 
 if [ ! -z "${JOBS}" ]; then

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -12,8 +12,14 @@ options="!check"
 
 depends="@(' '.join(depends))"
 makedepends="@(' '.join(makedepends))"
+@[if split_dev]@
+depends_dev="@(' '.joins(depends_dev))"
+
+subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
+@[else]@
 
 subpackages="$pkgname-dbg $pkgname-doc"
+@[end if]@
 
 source=""
 builddir="$startdir/abuild"

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -391,6 +391,14 @@ doc() {
   default_doc
 }
 
+@[if split_dev]@
+dev() {
+  mkdir -p $subpkgdir
+
+  default_dev
+}
+
+@[end if]
 if [ -f ./apkbuild_hook.sh ]; then
   . ./apkbuild_hook.sh
   apkbuild_hook

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -396,15 +396,7 @@ dev() {
   mkdir -p $subpkgdir
   install_if="${subpkgname%-dev}=$pkgver-r$pkgrel ros-dev"
 
-  for src in \
-      usr/ros/noetic/lib/pkgconfig/ \
-      usr/ros/noetic/share/*/cmake/; do
-    if [ -e "$pkgdir/$src" ]; then
-      mkdir -p "$subpkgdir/$src"
-      mv "$pkgdir/$src" "$subpkgdir/$src"
-      rmdir "$pkgdir/$src" 2>/dev/null || true
-    fi
-  done
+  amove usr/ros/*/lib/pkgconfig 'usr/ros/*/share/*/cmake/'
 
   default_dev
 }

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -394,6 +394,7 @@ doc() {
 @[if split_dev]@
 dev() {
   mkdir -p $subpkgdir
+  install_if="${subpkgname%-dev}=$pkgver-r$pkgrel ros-dev"
 
   default_dev
 }

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -398,13 +398,13 @@ dev() {
 
   for src in \
       usr/ros/noetic/lib/pkgconfig/ \
-      usr/ros/noetic/share/*/cmake/; then
+      usr/ros/noetic/share/*/cmake/; do
     if [ -e "$pkgdir/$src" ]; then
       mkdir -p "$subpkgdir/$src"
       mv "$pkgdir/$src" "$subpkgdir/$src"
       rmdir "$pkgdir/$src" 2>/dev/null || true
     fi
-  fi
+  done
 
   default_dev
 }

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -396,6 +396,16 @@ dev() {
   mkdir -p $subpkgdir
   install_if="${subpkgname%-dev}=$pkgver-r$pkgrel ros-dev"
 
+  for src in \
+      usr/ros/noetic/lib/pkgconfig/ \
+      usr/ros/noetic/share/*/cmake/; then
+    if [ -e "$pkgdir/$src" ]; then
+      mkdir -p "$subpkgdir/$src"
+      mv "$pkgdir/$src" "$subpkgdir/$src"
+      rmdir "$pkgdir/$src" 2>/dev/null || true
+    fi
+  fi
+
   default_dev
 }
 

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -396,7 +396,12 @@ dev() {
   mkdir -p $subpkgdir
   install_if="${subpkgname%-dev}=$pkgver-r$pkgrel ros-dev"
 
-  amove usr/ros/*/lib/pkgconfig 'usr/ros/*/share/*/cmake/'
+  if ls usr/ros/*/lib/pkgconfig >/dev/null 2>/dev/null; then
+    amove 'usr/ros/*/lib/pkgconfig'
+  fi
+  if ls usr/ros/*/share/*/cmake >/dev/null 2>/dev/null; then
+    amove 'usr/ros/*/share/*/cmake'
+  fi
 
   default_dev
 }

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -396,10 +396,10 @@ dev() {
   mkdir -p $subpkgdir
   install_if="${subpkgname%-dev}=$pkgver-r$pkgrel ros-dev"
 
-  if ls usr/ros/*/lib/pkgconfig >/dev/null 2>/dev/null; then
+  if ls $pkgdir/usr/ros/*/lib/pkgconfig >/dev/null 2>/dev/null; then
     amove 'usr/ros/*/lib/pkgconfig'
   fi
-  if ls usr/ros/*/share/*/cmake >/dev/null 2>/dev/null; then
+  if ls $pkgdir/usr/ros/*/share/*/cmake >/dev/null 2>/dev/null; then
     amove 'usr/ros/*/share/*/cmake'
   fi
 

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -13,7 +13,7 @@ options="!check"
 depends="@(' '.join(depends))"
 makedepends="@(' '.join(makedepends))"
 @[if split_dev]@
-depends_dev="@(' '.joins(depends_dev))"
+depends_dev="@(' '.join(depends_dev))"
 
 subpackages="$pkgname-dbg $pkgname-doc $pkgname-dev"
 @[else]@

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -125,9 +125,12 @@ def resolve(ros_distro, package_name, deps, add_ros_dev=False):
             continue
         installer = installer_context.get_installer(rule_installer)
         resolved = installer.resolve(rule)
-        print("d", json.dumps(d.data))
         for r in resolved:
             keys.append(r + dep.version)
+        if '_is_ros' in d.data:
+            if d.data['_is_ros']:
+                for r in resolved:
+                    keys.append(r + '-dev' + dep.version)
 
     if len(not_provided) > 0:
         print('Some packages are not provided by the native installer for ' + package_name +

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -253,14 +253,14 @@ def package_to_apkbuild(ros_distro, package_name,
         ros2_ros_workspaces_dependencies = ["ament_cmake_core", "ament_package", "ros_workspace"]
         if pkg.name not in ros2_ros_workspaces_dependencies:
             depends.append(NameAndVersion("ros_workspace", ""))
-    depends_keys = resolve(ros_distro, package_name, depends)
+    depends_keys = resolve(ros_distro, package_name, depends, add_ros_dev=split_dev)
 
     depends_export = []
     for dep in pkg.buildtool_export_depends:
         depends_export.append(ros_dependency_to_name_ver(dep))
     for dep in pkg.build_export_depends:
         depends_export.append(ros_dependency_to_name_ver(dep))
-    depends_export_keys = resolve(ros_distro, package_name, depends_export)
+    depends_export_keys = resolve(ros_distro, package_name, depends_export, add_ros_dev=split_dev)
 
     catkin = False
     cmake = False

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -322,13 +322,13 @@ def package_to_apkbuild(ros_distro, package_name,
         makedepends_implicit = force_py3_keys(makedepends_implicit)
 
     if split_dev:
-        apk_depends = depends_keys + depends_export_keys
-        apk_makedepends = makedepends_implicit + makedepends_keys
-        apk_depends_dev = []
-    else:
         apk_depends = list(filter(lambda x: not x.endswith('-dev'), depends_keys))
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = depends_export_keys + list(filter(lambda x: x.endswith('-dev'), depends_keys))
+    else:
+        apk_depends = depends_keys + depends_export_keys
+        apk_makedepends = makedepends_implicit + makedepends_keys
+        apk_depends_dev = []
 
     if ver_suffix is None:
         ver_suffix = ''

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -124,8 +124,12 @@ def resolve(ros_distro, package_name, deps, add_ros_dev=False):
             continue
         installer = installer_context.get_installer(rule_installer)
         resolved = installer.resolve(rule)
+        print("d", type(d))
+        print("rule", type(rule))
+        print("resolved", type(resolved))
         for r in resolved:
             keys.append(r + dep.version)
+
     if len(not_provided) > 0:
         print('Some packages are not provided by the native installer for ' + package_name +
               ': ' + ' '.join(not_provided), file=sys.stderr)

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -325,6 +325,10 @@ def package_to_apkbuild(ros_distro, package_name,
         apk_depends = list(filter(lambda x: not x.endswith('-dev'), depends_keys))
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = depends_export_keys + list(filter(lambda x: x.endswith('-dev'), depends_keys))
+        # Remove duplicated dependency keys
+        apk_depends = sorted(list(set(apk_depends)))
+        apk_makedepends = sorted(list(set(apk_makedepends)))
+        apk_depends_dev = sorted(list(set(apk_depends_dev)))
     else:
         apk_depends = depends_keys + depends_export_keys
         apk_makedepends = makedepends_implicit + makedepends_keys

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -338,7 +338,7 @@ def package_to_apkbuild(ros_distro, package_name,
 
     if split_dev:
         apk_depends = list(filter(is_not_dev, depends_keys))
-        apk_makedepends = makedepends_implicit + makedepends_keys
+        apk_makedepends = makedepends_implicit + makedepends_keys + list(filter(is_dev, depends_keys))
         apk_depends_dev = depends_export_keys + list(filter(is_dev, depends_keys))
         # Remove duplicated dependency keys
         apk_depends = sorted(list(set(apk_depends)))

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -324,9 +324,9 @@ def package_to_apkbuild(ros_distro, package_name,
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = []
     else:
-        apk_depends = filter(lambda x: not x.endsWith('-dev'), depends_keys))
+        apk_depends = filter(lambda x: not x.endsWith('-dev'), depends_keys)
         apk_makedepends = makedepends_implicit + makedepends_keys
-        apk_depends_dev = depends_export_keys + filter(lambda x: x.endsWith('-dev'), depends_keys))
+        apk_depends_dev = depends_export_keys + filter(lambda x: x.endsWith('-dev'), depends_keys)
 
     if ver_suffix is None:
         ver_suffix = ''

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -170,7 +170,7 @@ def static_revfn(rev):
 
 
 def is_dev(key):
-    return re.match(r'-dev([<>=]\S+)?$', key)
+    return re.match(r'^\S*-dev([<>=]\S+)?$', key) is not None
 
 
 def is_not_dev(key):

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -319,9 +319,14 @@ def package_to_apkbuild(ros_distro, package_name,
         makedepends_keys = force_py3_keys(makedepends_keys)
         makedepends_implicit = force_py3_keys(makedepends_implicit)
 
-    apk_depends = depends_keys + depends_export_keys
-    apk_makedepends = makedepends_implicit + makedepends_keys
-    apk_depends_dev = []
+    if split_dev:
+        apk_depends = depends_keys + depends_export_keys
+        apk_makedepends = makedepends_implicit + makedepends_keys
+        apk_depends_dev = []
+    else:
+        apk_depends = filter(lambda x: not x.endsWith('-dev'), depends_keys))
+        apk_makedepends = makedepends_implicit + makedepends_keys
+        apk_depends_dev = depends_export_keys + filter(lambda x: x.endsWith('-dev'), depends_keys))
 
     if ver_suffix is None:
         ver_suffix = ''

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -117,6 +117,8 @@ def resolve(ros_distro, package_name, deps, add_ros_dev=False):
             if '_is_ros' in e.rosdep_data:
                 if e.rosdep_data['_is_ros']:
                     keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version)
+                    if add_ros_dev:
+                        keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + "-dev" + dep.version)
                     continue
             not_provided.append(dep.name)
             continue

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -89,7 +89,7 @@ def load_lookup():
     return lookup
 
 
-def resolve(ros_distro, package_name, deps):
+def resolve(ros_distro, package_name, deps, add_ros_dev=False):
     lookup = load_lookup()
     installer_context = rosdep2.create_default_installer_context()
     os_name, os_version = installer_context.get_os_name_and_version()
@@ -107,6 +107,8 @@ def resolve(ros_distro, package_name, deps):
             d = view.lookup(dep.name)
         except KeyError as e:
             keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version)
+            if add_ros_dev:
+                keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version) + '-dev'
             continue
         try:
             rule_installer, rule = d.get_rule_for_platform(os_name, os_version, installer_keys, default_key)
@@ -296,7 +298,7 @@ def package_to_apkbuild(ros_distro, package_name,
         makedepends.append(ros_dependency_to_name_ver(dep))
     for dep in pkg.test_depends:
         makedepends.append(ros_dependency_to_name_ver(dep))
-    makedepends_keys = resolve(ros_distro, package_name, makedepends)
+    makedepends_keys = resolve(ros_distro, package_name, makedepends, add_ros_dev=split_dev)
 
     if depends_keys is None or depends_export_keys is None or makedepends_keys is None:
         sys.exit(1)

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -324,9 +324,9 @@ def package_to_apkbuild(ros_distro, package_name,
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = []
     else:
-        apk_depends = filter(lambda x: not x.endsWith('-dev'), depends_keys)
+        apk_depends = list(filter(lambda x: not x.endsWith('-dev'), depends_keys))
         apk_makedepends = makedepends_implicit + makedepends_keys
-        apk_depends_dev = depends_export_keys + filter(lambda x: x.endsWith('-dev'), depends_keys)
+        apk_depends_dev = depends_export_keys + list(filter(lambda x: x.endsWith('-dev'), depends_keys))
 
     if ver_suffix is None:
         ver_suffix = ''

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -169,6 +169,14 @@ def static_revfn(rev):
     return revfn
 
 
+def is_dev(key):
+    return re.match(r'-dev([<>=]\S+)?$', key)
+
+
+def is_not_dev(key):
+    return not is_dev(key)
+
+
 def package_to_apkbuild(ros_distro, package_name,
                         check=True, upstream=False, src=False, revfn=static_revfn(0),
                         ver_suffix=None, commit_hash=None, split_dev=False):
@@ -330,9 +338,9 @@ def package_to_apkbuild(ros_distro, package_name,
         makedepends_implicit = force_py3_keys(makedepends_implicit)
 
     if split_dev:
-        apk_depends = list(filter(lambda x: not x.endswith('-dev'), depends_keys))
+        apk_depends = list(filter(is_not_dev, depends_keys))
         apk_makedepends = makedepends_implicit + makedepends_keys
-        apk_depends_dev = depends_export_keys + list(filter(lambda x: x.endswith('-dev'), depends_keys))
+        apk_depends_dev = depends_export_keys + list(filter(is_dev, depends_keys))
         # Remove duplicated dependency keys
         apk_depends = sorted(list(set(apk_depends)))
         apk_makedepends = sorted(list(set(apk_makedepends)))

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -108,7 +108,7 @@ def resolve(ros_distro, package_name, deps, add_ros_dev=False):
         except KeyError as e:
             keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version)
             if add_ros_dev:
-                keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version) + '-dev'
+                keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + '-dev' + dep.version)
             continue
         try:
             rule_installer, rule = d.get_rule_for_platform(os_name, os_version, installer_keys, default_key)

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -324,9 +324,9 @@ def package_to_apkbuild(ros_distro, package_name,
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = []
     else:
-        apk_depends = list(filter(lambda x: not x.endsWith('-dev'), depends_keys))
+        apk_depends = list(filter(lambda x: not x.endswith('-dev'), depends_keys))
         apk_makedepends = makedepends_implicit + makedepends_keys
-        apk_depends_dev = depends_export_keys + list(filter(lambda x: x.endsWith('-dev'), depends_keys))
+        apk_depends_dev = depends_export_keys + list(filter(lambda x: x.endswith('-dev'), depends_keys))
 
     if ver_suffix is None:
         ver_suffix = ''

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -115,20 +115,19 @@ def resolve(ros_distro, package_name, deps, add_ros_dev=False):
             rule_installer, rule = d.get_rule_for_platform(os_name, os_version, installer_keys, default_key)
         except rosdep2.lookup.ResolutionError as e:
             # ignoring ROS packages since Alpine ROS packages are not solvable at now
-            if '_is_ros' in e.rosdep_data:
-                if e.rosdep_data['_is_ros']:
-                    keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version)
-                    if add_ros_dev:
-                        keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + "-dev" + dep.version)
-                    continue
+            if '_is_ros' in e.rosdep_data and e.rosdep_data['_is_ros']:
+                keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + dep.version)
+                if add_ros_dev:
+                    keys.append(ros_pkgname_to_pkgname(ros_distro, dep.name) + "-dev" + dep.version)
+                continue
             not_provided.append(dep.name)
             continue
         installer = installer_context.get_installer(rule_installer)
         resolved = installer.resolve(rule)
         for r in resolved:
             keys.append(r + dep.version)
-        if '_is_ros' in d.data:
-            if d.data['_is_ros']:
+        if add_ros_dev:
+            if '_is_ros' in d.data and d.data['_is_ros']:
                 for r in resolved:
                     keys.append(r + '-dev' + dep.version)
 

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -34,6 +34,7 @@ import subprocess
 import sys
 import yaml
 import re
+import json
 
 from catkin_pkg.package import Dependency, parse_package_string
 from rosdistro import get_cached_distribution, get_index, get_index_url
@@ -124,9 +125,7 @@ def resolve(ros_distro, package_name, deps, add_ros_dev=False):
             continue
         installer = installer_context.get_installer(rule_installer)
         resolved = installer.resolve(rule)
-        print("d", type(d))
-        print("rule", type(rule))
-        print("resolved", type(resolved))
+        print("d", json.dumps(d.data))
         for r in resolved:
             keys.append(r + dep.version)
 


### PR DESCRIPTION
- https://github.com/alpine-ros/ros-abuild-docker/issues/24
- requires https://github.com/seqsense/aports-ros-experimental/pull/970 to pass the tests
- docker images: https://github.com/alpine-ros/alpine-ros/pull/39

Automatically split dev dependencies and files to `-dev` subpackage.

All dev packages will be automatically installed if ros-dev meta package is installed.
We can install ros-dev to the base image by default to keep the default behavior.
Users can install packages without dev files by
`apk add !ros-dev ...`


### Dependencies

On master branch, `ros-noetic-rospack` had following deps
```
boost-dev
pkgconf
py3-catkin-pkg
py3-rosdep
python3-dev
ros-noetic-ros-environment
so:libboost_filesystem.so.1.84.0
so:libboost_program_options.so.1.84.0
so:libc.musl-x86_64.so.1
so:libgcc_s.so.1
so:libpython3.12.so.1.0
so:libstdc++.so.6
so:libtinyxml2.so.10
tinyxml2-dev
```

With `--split-dev` option, `ros-noetic-rospack` has
```
pkgconf
py3-catkin-pkg
py3-rosdep
ros-noetic-ros-environment
so:libboost_filesystem.so.1.84.0
so:libboost_program_options.so.1.84.0
so:libc.musl-x86_64.so.1
so:libgcc_s.so.1
so:libpython3.12.so.1.0
so:libstdc++.so.6
so:libtinyxml2.so.10
```
and `ros-noetic-rospack-dev` has
```
boost-dev
pkgconf
python3-dev
tinyxml2-dev
```

With `--split-dev` option, ROS packages in `build_depends` will be resolved as `ros-noetic-package` + `ros-noetic-package-dev` in APKBUILD.


### Files

For example, `ros-noetic-rostime` will contain
```
└── usr
    └── ros
        └── noetic
            ├── lib
            │   └── librostime.so
            └── share
                └── rostime
                    └── package.xml
```
and `ros-noetic-rostime-dev` will contain
```
└── usr
    └── ros
        └── noetic
            ├── include
            │   └── ros
            │       ├── duration.h
            │       ├── impl
            │       │   ├── duration.h
            │       │   └── time.h
            │       ├── rate.h
            │       ├── rostime_decl.h
            │       └── time.h
            ├── lib
            │   └── pkgconfig
            │       └── rostime.pc
            └── share
                └── rostime
                    └── cmake
                        ├── rostimeConfig.cmake
                        └── rostimeConfig-version.cmake
```