### PR TITLE
Fix depends_dev handling

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -393,8 +393,12 @@ doc() {
 @[if split_dev]@
 
 dev() {
+  local i=
   mkdir -p $subpkgdir
+
   install_if="${subpkgname%-dev}=$pkgver-r$pkgrel ros-dev"
+	depends="$depends_dev"
+	pkgdesc="$pkgdesc (development files)"
 
   cd $pkgdir || return 0
 


### PR DESCRIPTION
- https://github.com/alpine-ros/ros-abuild-docker/pull/173
- https://github.com/seqsense/aports-ros-experimental/pull/993#issuecomment-2255269748
- ref: https://github.com/alpinelinux/abuild/blob/97feb61beecf9cea256161584aeb43c9430bc475/abuild.in#L2047-L2050

`depends_dev` was handled in `default_dev` and must be done by the custom dev split function.