### PR TITLE
Add option to add catkin_make_isolated options

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -87,6 +87,10 @@ case "${ALPINE_VERSION}" in
     ;;
 esac
 
+for opt in ${CATKIN_OPTIONS}; do
+  generate_opts="${generate_opts} --catkin-option=${opt}"
+done
+
 echo "generate_opts: ${generate_opts}"
 
 # Setup environment variables

--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -102,6 +102,9 @@ build() {
 @[  end if]@
   source /usr/ros/@(ros_distro)/setup.sh
   catkin_make_isolated \
+@[  if catkin_options]@
+    @(catkin_options) \
+@[  end if]@
     -DCMAKE_BUILD_TYPE=RelWithDebInfo 2>&1 | tee $buildlog
 @[end if]@
 @[if is_ros2]@
@@ -149,6 +152,9 @@ check() {
   source /usr/ros/@(ros_distro)/setup.sh
   source devel_isolated/setup.sh
   catkin_make_isolated \
+@[    if catkin_options]@
+    @(catkin_options) \
+@[    end if]@
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     --catkin-make-args run_tests 2>&1 | tee $checklog
   catkin_test_results 2>&1 | tee $checklog
@@ -213,9 +219,15 @@ package() {
 @[if use_catkin]@
   source /usr/ros/@(ros_distro)/setup.sh
   catkin_make_isolated \
+@[  if catkin_options]@
+    @(catkin_options) \
+@[  end if]@
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     --install-space /usr/ros/@(ros_distro)
   catkin_make_isolated \
+@[  if catkin_options]@
+    @(catkin_options) \
+@[  end if]@
     -DCMAKE_BUILD_TYPE=RelWithDebInfo \
     --install --install-space /usr/ros/@(ros_distro)
   rm -f \

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -178,7 +178,7 @@ def is_not_dev(key):
 
 def package_to_apkbuild(ros_distro, package_name,
                         check=True, upstream=False, src=False, revfn=static_revfn(0),
-                        ver_suffix=None, commit_hash=None, split_dev=False):
+                        ver_suffix=None, commit_hash=None, split_dev=False, catkin_options=[]):
     pkg_xml = ''
     todo_upstream_clone = dict()
     ros_python_version = os.environ["ROS_PYTHON_VERSION"]
@@ -387,6 +387,7 @@ def package_to_apkbuild(ros_distro, package_name,
         'use_ament_python': ament_python,
         'is_ros2': is_ros2,
         'split_dev': split_dev,
+        'catkin_options': None if not catkin_options else ' '.join(catkin_options),
     }
     template_path = os.path.join(os.path.dirname(__file__), 'APKBUILD.em.sh')
     apkbuild = StringIO()
@@ -433,6 +434,9 @@ def main():
     parser.add_argument('--split-dev', action='store_const',
                         const=True, default=False,
                         help='split -dev packages (default: False)')
+    parser.add_argument('--catkin-option', dest='catkin_options',
+                        type=str, action='append', default=[],
+                        help='catkin optional arguments (default: [])')
     args = parser.parse_args()
 
     print(package_to_apkbuild(args.ros_distro[0], args.package[0],
@@ -440,7 +444,8 @@ def main():
                               src=args.src, revfn=static_revfn(args.rev),
                               ver_suffix=args.vsuffix,
                               commit_hash=args.commit,
-                              split_dev=args.split_dev))
+                              split_dev=args.split_dev,
+                              catkin_options=args.catkin_options))
 
 
 def main_multi():
@@ -468,6 +473,9 @@ example:
     parser.add_argument('--split-dev', action='store_const',
                         const=True, default=False,
                         help='split -dev packages (default: False)')
+    parser.add_argument('--catkin-option', dest='catkin_options',
+                        type=str, action='append', default=[],
+                        help='catkin optional arguments (default: [])')
     args = parser.parse_args()
 
     pkglist = None
@@ -527,7 +535,8 @@ example:
             upstream=(args.upstream or pkg_force_upstream),
             revfn=revfn,
             commit_hash=pkg_upstream_ref,
-            split_dev=args.split_dev)
+            split_dev=args.split_dev,
+            catkin_options=args.catkin_options)
 
         directory = os.path.dirname(filepath)
         if not os.path.exists(directory):


### PR DESCRIPTION
Mainly for CI.
For example, pass `-DCMAKE_C_FLAGS=-coverage -DCMAKE_CXX_FLAGS=-coverage` to generate coverage reports and extract them on CI.