### PR TITLE
Fix environment variable override script on recent Alpine versions

### DIFF
--- a/build-repo.sh
+++ b/build-repo.sh
@@ -100,6 +100,9 @@ echo 'export MAKEFLAGS="${MAKEFLAGS} -j${JOBS} -l${JOBS}"/' | sudo tee -a /etc/a
 if [ ! -z "${CFLAGS}" ]; then
   echo "export CFLAGS=\"\${CFLAGS} ${CFLAGS}\"/" | sudo tee -a /etc/abuild.conf
 fi
+if [ ! -z "${CXXFLAGS}" ]; then
+  echo "export CXXFLAGS=\"\${CXXFLAGS} ${CXXFLAGS}\"/" | sudo tee -a /etc/abuild.conf
+fi
 
 if [ ${ENABLE_CCACHE} = "yes" ]
 then


### PR DESCRIPTION
Recent version of `/etc/abuild.conf` doesn't contain default environment variables.
(default settings are moved to `/usr/share/abuild/default.conf`)

Fix script to override environment variables: JOBS, MAKEFLAGS and CFLAGS
Also support overriding CXXFLAGS.