### PR TITLE
Collect only files when gathering license texts

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -301,6 +301,10 @@ package() {
       -iname "copying*" -or \
       -iname "gnu-*gpl*" \
     | while read file; do
+    if [ ! -f "$file" ]; then
+      # Omit directories named like a license file
+      continue
+    fi
     # Copy license files under the source
     if echo $file | grep -e '^\./\.'; then
       # Omit files under hidden directory


### PR DESCRIPTION
## Problem

The license sweep in the generated `package()` feeds `find`'s output straight to `install -Dm644`:

```sh
find . \
    -iname "license*" -or \
    -iname "copyright*" -or \
    -iname "copying*" -or \
    -iname "gnu-*gpl*" \
  | while read file; do
  ...
  install -Dm644 $file "$licensedir"/$file
done
```

`find` matches directories as readily as files, and `install -Dm644` refuses one. A source tree with a directory named after any of these patterns aborts packaging:

```
Copying license files from source tree: ./src/cpp/utils/license
install: omitting directory './src/cpp/utils/license'
>>> ERROR: ros-jazzy-fastrtps*: package failed
>>> ERROR: ros-jazzy-fastrtps: rootpkg failed
```

`fastrtps` has `src/cpp/utils/license/LicenseTools.hpp`, so the enclosing directory matches `-iname "license*"`. Its real `./LICENSE` had already been collected seven lines earlier — the build had everything it needed and failed anyway. A dangling symlink fails the same way, with `can't stat`.

## Change

Test each candidate with `-f` at the top of the loop and skip anything that is not a regular file:

```sh
| while read file; do
    if [ ! -f "$file" ]; then
      # Omit directories named like a license file
      continue
    fi
```

Filtering `find` with `-type f` would also drop directories, but `-type` inspects the link itself, so a `LICENSE` symlinked to a regular file — which `install` handles perfectly well, copying the target — would be dropped and the package would ship without its license text. The shell's `-f` follows the link, so such a symlink still counts.

## Verification

Against a tree shaped like fastrtps — a real `./LICENSE`, a `./doc/COPYING`, a `./src/cpp/utils/license/` directory — plus a `COPYING.link` symlink to a regular file and a dangling `LICENSE.broken` symlink:

| candidate | before | after |
|---|---|---|
| `./LICENSE` (regular file) | installed | installed |
| `./doc/COPYING` (regular file) | installed | installed |
| `./COPYING.link` (symlink → regular file) | installed | installed |
| `./src/cpp/utils/license/` (directory) | **`install` fails, package aborts** | skipped |
| `./LICENSE.broken` (dangling symlink) | **`install` fails, package aborts** | skipped |

Files that genuinely carry license text are unaffected; only the non-regular entries drop out. This does not descend into such a directory to collect what is inside it — `LicenseTools.hpp` does not match the name patterns either way — so behaviour is otherwise unchanged.

Seen on seqsense/aports-ros-experimental#1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
