### PR TITLE
Provide pytest to check() through checkdepends

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -12,6 +12,9 @@ options="!check"
 
 depends="@(' '.join(depends))"
 makedepends="@(' '.join(makedepends))"
+@[if checkdepends]@
+checkdepends="@(' '.join(checkdepends))"
+@[end if]@
 @[if split_dev]@
 depends_dev="@(' '.join(depends_dev))"
 

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -351,6 +351,20 @@ def package_to_apkbuild(ros_distro, package_name,
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = []
 
+    # check() runs "python -m pytest" for a Python package whose setup.py
+    # mentions pytest. That decision is made from setup.py, while makedepends
+    # comes from package.xml, so a package that uses pytest without declaring
+    # it -- ament_flake8, for one -- fails the check with "No module named
+    # pytest". Put it in checkdepends, which abuild installs for check() only,
+    # so neither depends nor makedepends grows.
+    apk_checkdepends = []
+    if check and ament_python:
+        apk_checkdepends = resolve(
+            ros_distro, package_name, [NameAndVersion('python3-pytest', '')]) or []
+        if ros_python_version == '3':
+            apk_checkdepends = force_py3_keys(apk_checkdepends)
+        apk_checkdepends = sorted(set(apk_checkdepends))
+
     if ver_suffix is None:
         ver_suffix = ''
 
@@ -374,6 +388,7 @@ def package_to_apkbuild(ros_distro, package_name,
         'check': check,
         'depends': apk_depends,
         'makedepends': apk_makedepends,
+        'checkdepends': apk_checkdepends,
         'depends_dev': apk_depends_dev,
         'ros_python_version': os.environ["ROS_PYTHON_VERSION"],
         'rosinstall': None if src else yaml.dump(rosinstall),

--- a/generate_rospkg_apkbuild/genapkbuild.py
+++ b/generate_rospkg_apkbuild/genapkbuild.py
@@ -319,13 +319,23 @@ def package_to_apkbuild(ros_distro, package_name,
         makedepends.append(ros_dependency_to_name_ver(dep))
     makedepends_keys = resolve(ros_distro, package_name, makedepends, add_ros_dev=split_dev)
 
-    if depends_keys is None or depends_export_keys is None or makedepends_keys is None:
+    # check() may run "python -m pytest" even when package.xml does not
+    # declare pytest, so provide it to every Python package through
+    # checkdepends, which is installed for check() only.
+    checkdepends_keys = []
+    if check and ament_python:
+        checkdepends_keys = resolve(
+            ros_distro, package_name, [NameAndVersion('python3-pytest', '')])
+
+    if (depends_keys is None or depends_export_keys is None
+            or makedepends_keys is None or checkdepends_keys is None):
         sys.exit(1)
 
     # Remove duplicated dependency keys
     depends_keys = sorted(list(set(depends_keys)))
     depends_export_keys = sorted(list(set(depends_export_keys)))
     makedepends_keys = sorted(list(set(makedepends_keys)))
+    checkdepends_keys = sorted(list(set(checkdepends_keys)))
 
     makedepends_implicit = [
         'py-setuptools', 'py-rosdep',
@@ -336,6 +346,7 @@ def package_to_apkbuild(ros_distro, package_name,
         depends_keys = force_py3_keys(depends_keys)
         depends_export_keys = force_py3_keys(depends_export_keys)
         makedepends_keys = force_py3_keys(makedepends_keys)
+        checkdepends_keys = force_py3_keys(checkdepends_keys)
         makedepends_implicit = force_py3_keys(makedepends_implicit)
 
     if split_dev:
@@ -350,20 +361,6 @@ def package_to_apkbuild(ros_distro, package_name,
         apk_depends = depends_keys + depends_export_keys
         apk_makedepends = makedepends_implicit + makedepends_keys
         apk_depends_dev = []
-
-    # check() runs "python -m pytest" for a Python package whose setup.py
-    # mentions pytest. That decision is made from setup.py, while makedepends
-    # comes from package.xml, so a package that uses pytest without declaring
-    # it -- ament_flake8, for one -- fails the check with "No module named
-    # pytest". Put it in checkdepends, which abuild installs for check() only,
-    # so neither depends nor makedepends grows.
-    apk_checkdepends = []
-    if check and ament_python:
-        apk_checkdepends = resolve(
-            ros_distro, package_name, [NameAndVersion('python3-pytest', '')]) or []
-        if ros_python_version == '3':
-            apk_checkdepends = force_py3_keys(apk_checkdepends)
-        apk_checkdepends = sorted(set(apk_checkdepends))
 
     if ver_suffix is None:
         ver_suffix = ''
@@ -388,7 +385,7 @@ def package_to_apkbuild(ros_distro, package_name,
         'check': check,
         'depends': apk_depends,
         'makedepends': apk_makedepends,
-        'checkdepends': apk_checkdepends,
+        'checkdepends': checkdepends_keys,
         'depends_dev': apk_depends_dev,
         'ros_python_version': os.environ["ROS_PYTHON_VERSION"],
         'rosinstall': None if src else yaml.dump(rosinstall),


### PR DESCRIPTION
## Problem

The generated `check()` decides how to run a Python package's tests by grepping `setup.py`:

```sh
USE_PYTEST=$(grep '\<pytest\>' setup.py) || true
if [ -n "$USE_PYTEST" ]; then
  python -m pytest 2>&1 | tee $checklog
else
  python setup.py test 2>&1 | tee $checklog
fi
```

`makedepends`, meanwhile, is derived from `package.xml`. Nothing reconciles the two. A package whose `setup.py` uses pytest but whose `package.xml` omits `<test_depend>python3-pytest</test_depend>` therefore takes the pytest branch with no pytest installed:

```
Installing ament_flake8 script to .../bin
/usr/bin/python: No module named pytest
>>> ERROR: ros-humble-ament-flake8: check failed
```

`ament_flake8` 0.12.15 is a live example — seen on seqsense/aports-ros-experimental#1278. Being a lint package, it takes everything downstream of it with it.

## Change

Emit the dependency as `checkdepends`, which abuild installs for `check()` and removes afterwards, so neither `depends` nor `makedepends` grows.

The package name is not written out; it comes from resolving the rosdep key `python3-pytest`, keeping the mapping in one place. On Alpine that is `py3-pytest7` today.

Only Python packages get the entry, and only when checks are enabled. Within that set the entry is unconditional: the pytest-vs-`setup.py test` choice is made at build time from a `setup.py` this generator never sees (only `package.xml` is available at generation time), so pytest goes to every Python package rather than only to the ones that turn out to need it. `checkdepends` keeps that over-approximation cheap — the package never reaches the final apk.

## Verification

Generated with the modified image on `3.23-humble`:

| package | kind | `checkdepends` |
|---|---|---|
| `ament_flake8` | Python, uses pytest | `py3-pytest7` |
| `ament_index_python` | Python | `py3-pytest7` |
| `rclcpp` | C++ | *(absent)* |

`makedepends` is unchanged in all three.

Building `ament_flake8` end to end:

```
>>> ros-humble-ament-flake8: Installing for build: ... py3-pytest7
(19/21) Installing py3-pytest7 (7.4.4-r3)
...
============================= test session starts ==============================
platform linux -- Python 3.12.13, pytest-7.4.4, pluggy-1.6.0
configfile: pytest.ini
============================== 1 passed in 0.08s ===============================
...
(15/21) Purging py3-pytest7 (7.4.4-r3)
>>> ros-humble-ament-flake8: Updating the humble/x86_64 repository index...
```

The tests run and pass, and pytest is gone again by the end. The same package fails at `check` without this change.

## Alternative considered

Having `check()` fall back to `setup.py test` when pytest is missing would also stop the failure, but it would silently skip tests that only run under pytest. Installing what `check()` asks for seemed the better trade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
