### PR TITLE
Run tests one at a time in check()

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -177,7 +177,10 @@ check() {
   make install DESTDIR="$builddir"/tmp/pkg
 @[  end if]@
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
-    make test 2>&1 | tee $checklog
+    # Run tests one at a time: ROS tests share the default DDS domain, and
+    # upstream only ever runs them sequentially. The -j1 is explicit because
+    # ctest otherwise picks up parallelism from MAKEFLAGS.
+    ctest -j1 2>&1 | tee $checklog
   fi
 @[  end if]@
 @[  if use_ament_python]@


### PR DESCRIPTION
## Problem

`check()` runs `make test`, and ctest connects to make's jobserver — the log says so outright:

```
Test project /home/builder/aports/jazzy/ros-jazzy-rclpy/abuild/build
Connected to MAKE jobserver
      Start  1: cppcheck
      Start  2: test_python_allocator
      Start  3: test_action_client
      Start  4: test_action_graph
```

Tests therefore run with the build parallelism (`JOBS`). Tests of a ROS package share the default DDS domain, so nodes belonging to unrelated tests discover each other: a test reads back parameters another test set, localization receives another test's point clouds, service calls time out. The symptoms look scattered and flaky, but they are one mechanism.

Nothing upstream ever runs a package's tests concurrently. colcon invokes ctest [with no `-j`](https://github.com/colcon/colcon-cmake/blob/master/colcon_cmake/task/cmake/test.py), so wherever colcon is the runner, tests within a package are sequential — and ci.ros2.org adds [`--executor sequential`](https://github.com/ros2/ci/blob/master/create_jenkins_job.py) on top of that. The parallel check here is an execution mode no ROS package is written for; the `disable-flaky-test.patch` files scattered through aports are, in part, the scar tissue.

## Evidence

Measured on `mcl_3dl` (ROS 2, jazzy, 31 tests, 8 of them launch tests), same sources throughout:

| ctest | DDS domain | result |
|---|---|---|
| parallel (`make test`, jobserver) | shared | **5 launch tests fail / time out** |
| parallel | per-test domain | 31/31 pass |
| **serial (`ctest -j1`)** | shared | **31/31 pass** |

The same five tests fail identically on Ubuntu 24.04 (jazzy) with parallel ctest and pass with `-j1` — so this is a concurrency problem, not an Alpine/musl one.

## Change

Call ctest directly with an explicit `-j1`. Both halves matter, both measured:

- under `make test`, ctest inherits the jobserver;
- called directly with no arguments, ctest *still* picks up the parallelism from `MAKEFLAGS` in the environment (4-wide with no jobserver connected).

## Cost

`mcl_3dl`: check 74s → 163s; the whole package job 389s → 432s (+11%), since dependency installation and compilation dominate. The pathological case is a suite whose tests time out — the timeouts now accumulate serially — but such a suite was failing anyway.

## Scope

`check()` is baked into every committed APKBUILD, so this takes effect as APKBUILDs are regenerated; existing ones keep the old behavior until then.

For completeness: serialization is not a cure-all. `rclpy` 7.1.11 on jazzy/Alpine 3.20 fails 32/56 identically under `-j1` and under parallel — those failures are deterministic (Fast DDS type errors at node construction, i.e. a package-set skew on that repo) and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)