### PR TITLE
Allow packages to opt into retrying flaky tests in check()

### DIFF
--- a/generate_rospkg_apkbuild/APKBUILD.em.sh
+++ b/generate_rospkg_apkbuild/APKBUILD.em.sh
@@ -182,8 +182,10 @@ check() {
   if [ $(make -q test > /dev/null 2> /dev/null; echo $?) -eq 1 ]; then
     # Run tests one at a time: ROS tests share the default DDS domain, and
     # upstream only ever runs them sequentially. The -j1 is explicit because
-    # ctest otherwise picks up parallelism from MAKEFLAGS.
-    ctest -j1 2>&1 | tee $checklog
+    # ctest otherwise picks up parallelism from MAKEFLAGS. A package with
+    # known-flaky tests can set check_retries in its apkbuild_hook.sh to give
+    # failing tests that many attempts (like colcon's --retest-until-pass).
+    ctest -j1 ${check_retries:+--repeat "until-pass:${check_retries}"} 2>&1 | tee $checklog
   fi
 @[  end if]@
 @[  if use_ament_python]@


### PR DESCRIPTION
Follow-up to #196. ROS test suites lean on timing — DDS discovery, transient-local topic delivery inside a fixed grace period, executor scheduling — and on a loaded builder some of them fail spuriously, taking the whole package build with them. Measured while rebuilding the full jazzy-3.23 update set (262 packages, seqsense/aports-ros-experimental#1297):

- `nav2_costmap_2d` / `test_collision_checker`: publishes costmap+footprint, sleeps a fixed 1 s, then asserts — failed 3 of 5 otherwise-identical runs
- `nav2_velocity_smoother` tests under load
- `rcl` discovery tests, previously only survivable by rerunning a half-hour CI leg

So far the only remedies have been disabling such tests outright or close/reopening PRs.

## Change

`check()` gains an **opt-in, per-package** retry:

```sh
ctest -j1 ${check_retries:+--repeat "until-pass:${check_retries}"} 2>&1 | tee $checklog
```

A package marks its tests as flaky in its `apkbuild_hook.sh`:

```sh
apkbuild_hook() {
  check_retries=3
}
```

`--repeat until-pass:<n>` reruns **only the tests that failed**, up to n attempts total, and still fails the run if a test never passes — the policy colcon offers as `--retest-until-pass`. Same mechanism and granularity as the existing per-package test-disabling patches, but without giving up the coverage.

Unset (the default everywhere), the command is exactly as today — deliberately **not** enabled globally: a genuinely broken package would take up to n× longer to report failure, and timeout-heavy suites make that expensive (rclpy under the fastrtps ABI skew spent 40 minutes failing 32 tests; tripling that helps nobody).

Requires CMake ≥ 3.17 where opted in: Alpine 3.20 ships 3.29, 3.23 ships 4.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
